### PR TITLE
Revamp the HA plugin

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/ambv/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+        language_version: python3
+        args: ['--line-length=120']

--- a/README.md
+++ b/README.md
@@ -1,52 +1,179 @@
 # HomeAssistant-BMR
-Custom component - climate platform - for BMR HC64 Heating Controller units for Home Assistant.
 
-Producer's website: https://www.bmr.cz/menu-produkty/menu-regulace-vytapeni/webove-rozhrani-ovladani-hc64
+Home Assistant integration plugin for [BMR HC64 heating
+controller](https://bmr.cz/produkty/regulace-topeni/rnet). This controller has
+many quirks but overall it is quite usable in Home Assistant.  The plugin
+provides entities from these HA domains:
+
+- `binary_sensor`
+- `climate`
+- `sensor`
+- `switch`
 
 
-## Manuel Installation:
-Copy file custom_components/bmr/climate.py to custom_components/bmr/climate.py
+## Installation
 
-## Usage:
-Add this to configuration.yaml to respective sections:
+For normal use, use HACS to install the plugin.
+
+Alternatively you can install the plugin manually: copy `custom_components/` to
+your Home Assistant config directory.
+
+
+## Usage
+
+### Binary Sensor
+
+Provided entities:
+
+- `binary_sensor.bmr_hc64_hdo`: Binary sensor for indicating whether the state
+  of HDO (low/high electricity tariff)
+
+Example configuration:
+
+```
+binary_sensor:
+  - platform: bmr_hc64
+    base_url: "http://192.168.3.254/"
+    username: !secret bmr_username
+    password: !secret bmr_password
+```
+
+
+### Climate
+
+This works as a thermostat. it supports setting HVAC mode, setting target
+temperature, power off and away mode.
+
+Provided entities:
+
+-  `climate.bmr_hc64_<name>` (for every configured circuit)
+
+Example configuration:
+
 ```
 climate:
-  - platform: bmr
-    host: [IP ADDRESS TO ATREA UNIT]
-    username: [USER NAME FOR WEB UI TO ATREA UNIT]
-    password: [PASSWORD FOR WEB UI TO ATREA UNIT]
-    honza:
-      - name: <name of room/circuit>
-        schedule_mode_id: <Go to BMR web ui "Nastaveni rezimu" and count from top starting by 0>
-        ai_mode_id: <Similar as above but this a mode dedicated by external script - out of scope>
-        floor: <Go to BMR web ui "Nastaveni topeni okruhu" and count from top starting by 0. This circuit is supposed to fetch temperature from a floor sensor>
-        room: <Go to BMR web ui "Nastaveni topeni okruhu" and count from top starting by 0. This circuit is supposed to fetch temperature from a room sensor>
+  - platform: bmr_hc64
+    base_url: "http://192.168.3.254/"
+    username: !secret bmr_username
+    password: !secret bmr_password
+    away_temperature: 18.0
+    circuits:
+      - name: "Living room"
+        circuit: 8
+        schedule:
+          day_schedules: [0]
+        schedule_override: 16
 
+      - name: "Kitchen"
+        circuit: 9
+        schedule:
+          day_schedules: [1]
+        schedule_override: 17
 
-# This is to display active overall mode read from the BMR
-sensor:
-  - platform: bmr
-    host: 192.168.1.5
-    username: hass
-    password: !secret bmr
-
-# HDO signal
-binary_sensor:
-  - platform: bmr
-    host: 192.168.1.5
-    username: hass
-    password: !secret bmr
-
-# This dropdown is used to set overall modes to BMR 
-input_select:
-  bmr_rezim:
-    name: Režim topeni
-    options:
-      - auto
-      - rozvrh
-      - vypnuto
-      - utlum
-    icon: mdi:radiator
+      # etc.
 ```
+
+The `circuits` key specifies circuits that will be handled by the plugin.
+Usually the circuit will correspond to the room it is located in, but sometimes
+the circuit can heat multiple rooms as well.
+
+The HC64 controller usually has two circuits per room - the "room" circuit
+(measuring air temperature) and "floor" circuit (measuring floor temperature).
+The heating starts when both circuits "want" to heat (their current temperature
+is lower than their target temperature). This is unneccesarily complicated and
+sometimes results in unpredictable behaviour so it is recommended to configure
+the floor circuit in such a way that it almost always "wants" to heat by
+setting its target temperature to a high value (e.g. 32 C) and control the
+temperature using the "room" sensor. *This plugin assumes that your heating
+setup works like this and the specified circuit is the "room circuit, not the
+floor circuit.*
+
+Supported HVAC modes:
+
+- Auto: Let the heating controller manage the temperature automatically using
+  the configured schedules in `circuits.schedule`. The key `day_schedules`
+  contains up to 21 schedules that are rotated daily, similarly it's in the
+  HC64 Web UI.
+
+- Heating: Set target temperature for the circuit manually. Internally this
+  works by switching the circuit to schedule specified in `schedule_override`
+  and setting the override schedule to the user-defined target temperature.
+  Make sure the override schedule is not used for something else. The reason
+  for using a special schedule for overriding temperature is to preserve the
+  schedule used in automatic mode.
+
+- Off: Turn off the circuit. Internally this works by assigning the circuit
+  into "summer mode" and turning the summer mode on. *When running the plugin
+  for the first time make sure there are no circuits assigned to summer mode,
+  otherwise turning the circuit off using this HVAC mode will turn these
+  additional circuits as well*.
+
+There is 1 "preset mode" available as well:
+
+- "Away" mode: Turn on the "away" mode which will set the target temperature of
+  all specified circuits to `away_temperature`. Intenally this works by turning
+  on the "low" mode of the HC64 controller assigning the circuits. *When
+  running the plugin for the first time make sure your room circuits are
+  assigned to "low" mode, this plugin will not change low mode circuit
+  assignments (as opposed to the "summer" mode assignments, which it does change).*
+
+
+### Sensor
+
+Read-only sensor for reporting current and target temperature of circuits.
+
+Provided entities:
+
+- `sensor.bmr_hc64_<name>_temperature` (for every configured circuit)
+- `sensor.bmr_hc64_<name>_target_temperature` (for every configured circuit)
+
+Example configuration:
+
+```
+sensor:
+  - platform: bmr_hc64
+    base_url: "http://192.168.3.254/"
+    username: !secret bmr_username
+    password: !secret bmr_password
+    circuits:
+      - name: "Living room"
+        circuit: 8
+
+      - name: "Kitchen"
+        circuit: 9
+```
+
+### Switch
+
+Switches for controlling the "Away" mode and "Power".
+
+Provided entities:
+
+- `switch.bmr_hc64_away`
+- `switch.bmr_hc64_power`
+
+Example configuration:
+
+```
+switch:
+  - platform: bmr_hc64
+    base_url: "http://192.168.3.254/"
+    username: !secret bmr_username
+    password: !secret bmr_password
+    circuits:
+      - name: "Living room"
+        circuit: 8
+
+      - name: "Kitchen"
+        circuit: 9
+```
+
+The `switch.bmr_hc64_away` switch will turn on/off the "Away" mode globally. As
+described above, internally this works by turning on the "low" mode.
+
+The `switch.bmr_hc64_power` switch controls power of all circuits globally. As
+described above, internally this works by and assigning all the specified
+circuits to "summer" mode and enabling the "summer" mode.
+
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg?style=for-the-badge)](https://github.com/custom-components/hacs)

--- a/custom_components/bmr/binary_sensor.py
+++ b/custom_components/bmr/binary_sensor.py
@@ -5,38 +5,30 @@ configuration.yaml
 
 binary_sensor:
   - platform: bmr
-    host: ip
+    base_url: http://ip-address/
     user: user
     password: password
 """
 
-__version__ = "1.0"
+__version__ = "0.7"
 
 import logging
-import voluptuous as vol
-
+import socket
 from datetime import timedelta
 
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-
-from homeassistant.const import (
-    STATE_ON,
-    STATE_OFF,
-    CONF_NAME,
-    CONF_HOST,
-    CONF_USERNAME,
-    CONF_PASSWORD,
-)
 import homeassistant.helpers.config_validation as cv
-from homeassistant.components.binary_sensor import BinarySensorDevice
-from homeassistant.util import Throttle
+import voluptuous as vol
+from homeassistant.components.binary_sensor import PLATFORM_SCHEMA, BinarySensorEntity
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.util import Throttle as throttle
 
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
 _LOGGER = logging.getLogger(__name__)
+
+CONF_BASE_URL = "base_url"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_BASE_URL): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
     }
@@ -46,53 +38,44 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     import pybmr
 
-    host = config.get(CONF_HOST)
+    base_url = config.get(CONF_BASE_URL)
     user = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    bmr = pybmr.Bmr(host, user, password)  # Test connectivity
-    cnt = bmr.getNumCircuits()
-    if cnt == None:
-        raise Exception("Cannot connect to BMR")
-    sensors = []
-    sensors.append(Hdo(bmr))
+    bmr = pybmr.Bmr(base_url, user, password)
+    sensors = [
+        BmrControllerHDO(bmr),
+    ]
+
     add_entities(sensors)
 
 
-class Hdo(BinarySensorDevice):
-    def __init__(self, bmr):
-        import pybmr
+class BmrControllerHDO(BinarySensorEntity):
+    """ Binary sensor for reporting HDO (low/high electricity tariff).
+    """
 
+    def __init__(self, bmr):
         self._bmr = bmr
-        self._icon = "mdi:restart"
-        self._state = None
-        self.update()
+        self._hdo = None
 
     @property
     def name(self):
-        return "HDO"
-
-    @property
-    def should_poll(self):
-        return True
-
-    @property
-    def unit_of_measurement(self):
-        return "nizky tarif"
-
-    @property
-    def icon(self):
-        return self._icon
+        """ Return the name of the sensor.
+        """
+        return "BMR HC64 HDO"
 
     @property
     def is_on(self):
-        return self._state
+        """ Return the state of the sensor.
+        """
+        return bool(self._hdo)
 
-    @property
-    def device_class(self):
-        return "plug"
-
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
+    @throttle(timedelta(seconds=30))
     def update(self):
-        self._state = self._bmr.loadHDO()
-        self._icon = "mdi:power-plug" if self._state else "mdi:power-plug-off"
+        """ Fetch new state data for the sensor.
+            This is the only method that should fetch new data for Home Assistant.
+        """
+        try:
+            self._hdo = self._bmr.getHDO()
+        except socket.timeout:
+            _LOGGER.warn("Read from BMR HC64 controller timed out. Retrying later.")

--- a/custom_components/bmr/binary_sensor.py
+++ b/custom_components/bmr/binary_sensor.py
@@ -19,7 +19,14 @@ from datetime import timedelta
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 
-from homeassistant.const import (STATE_ON, STATE_OFF, CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD)
+from homeassistant.const import (
+    STATE_ON,
+    STATE_OFF,
+    CONF_NAME,
+    CONF_HOST,
+    CONF_USERNAME,
+    CONF_PASSWORD,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.util import Throttle
@@ -27,19 +34,23 @@ from homeassistant.util import Throttle
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    }
+)
+
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     import pybmr
+
     host = config.get(CONF_HOST)
     user = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    bmr = pybmr.Bmr(host, user, password) # Test connectivity
+    bmr = pybmr.Bmr(host, user, password)  # Test connectivity
     cnt = bmr.getNumCircuits()
     if cnt == None:
         raise Exception("Cannot connect to BMR")
@@ -49,9 +60,9 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 
 class Hdo(BinarySensorDevice):
-
     def __init__(self, bmr):
         import pybmr
+
         self._bmr = bmr
         self._icon = "mdi:restart"
         self._state = None
@@ -59,7 +70,7 @@ class Hdo(BinarySensorDevice):
 
     @property
     def name(self):
-        return 'HDO'
+        return "HDO"
 
     @property
     def should_poll(self):
@@ -67,7 +78,7 @@ class Hdo(BinarySensorDevice):
 
     @property
     def unit_of_measurement(self):
-        return 'nizky tarif'
+        return "nizky tarif"
 
     @property
     def icon(self):
@@ -79,11 +90,9 @@ class Hdo(BinarySensorDevice):
 
     @property
     def device_class(self):
-        return 'plug'
+        return "plug"
 
     @Throttle(MIN_TIME_BETWEEN_SCANS)
     def update(self):
         self._state = self._bmr.loadHDO()
-        self._icon = 'mdi:power-plug' if self._state else 'mdi:power-plug-off'
-
-
+        self._icon = "mdi:power-plug" if self._state else "mdi:power-plug-off"

--- a/custom_components/bmr/binary_sensor.py
+++ b/custom_components/bmr/binary_sensor.py
@@ -58,11 +58,19 @@ class BmrControllerHDO(BinarySensorEntity):
         self._bmr = bmr
         self._hdo = None
 
+        self._unique_id = f"{self._bmr.getUniqueId()}-binary-sensor-hdo"
+
     @property
     def name(self):
         """ Return the name of the sensor.
         """
         return "BMR HC64 HDO"
+
+    @property
+    def unique_id(self):
+        """ Return unique ID of the entity.
+        """
+        return self._unique_id
 
     @property
     def is_on(self):

--- a/custom_components/bmr/climate.py
+++ b/custom_components/bmr/climate.py
@@ -19,19 +19,39 @@ import re
 
 from datetime import timedelta
 
-from homeassistant.components.climate import (ClimateEntity, PLATFORM_SCHEMA)
-from homeassistant.components.climate.const import (SUPPORT_TARGET_TEMPERATURE, ATTR_HVAC_MODE, HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_COOL, HVAC_MODE_HEAT_COOL, CURRENT_HVAC_OFF, CURRENT_HVAC_HEAT, CURRENT_HVAC_COOL, CURRENT_HVAC_IDLE)
+from homeassistant.components.climate import ClimateEntity, PLATFORM_SCHEMA
+from homeassistant.components.climate.const import (
+    SUPPORT_TARGET_TEMPERATURE,
+    ATTR_HVAC_MODE,
+    HVAC_MODE_OFF,
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+    HVAC_MODE_HEAT_COOL,
+    CURRENT_HVAC_OFF,
+    CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_COOL,
+    CURRENT_HVAC_IDLE,
+)
 
-from homeassistant.const import (STATE_ON, STATE_OFF, CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD, TEMP_CELSIUS, ATTR_TEMPERATURE)
+from homeassistant.const import (
+    STATE_ON,
+    STATE_OFF,
+    CONF_NAME,
+    CONF_HOST,
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    TEMP_CELSIUS,
+    ATTR_TEMPERATURE,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
 _LOGGER = logging.getLogger(__name__)
-#DEFAULT_NAME = "BMR"
-#STATE_MANUAL = 'manual'
-#STATE_UNKNOWN = 'unknown'
+# DEFAULT_NAME = "BMR"
+# STATE_MANUAL = 'manual'
+# STATE_UNKNOWN = 'unknown'
 BMR_WARN_CANNOTCONNECT = 9
 HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_AUTO, HVAC_MODE_HEAT_COOL]
 
@@ -48,25 +68,28 @@ CHANNEL_SCHEMA = vol.Schema(
         vol.Optional(SCH_MODE_ID): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
         vol.Optional(AI_MODE_ID): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
         vol.Optional(FLOOR): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
-        vol.Optional(ROOM): vol.All(vol.Coerce(int), vol.Range(min=0, max=31))
+        vol.Optional(ROOM): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
     }
 )
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string,
-    vol.Required(CHANNELS): vol.All(cv.ensure_list, [CHANNEL_SCHEMA])
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CHANNELS): vol.All(cv.ensure_list, [CHANNEL_SCHEMA]),
+    }
+)
 
 
 def setup_platform(hass, config, add_devices, discovery_info=None):
     import pybmr
+
     host = config.get(CONF_HOST)
     user = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    bmr = pybmr.Bmr(host, user, password) # Test connectivity
+    bmr = pybmr.Bmr(host, user, password)  # Test connectivity
     cnt = bmr.getNumCircuits()
     if cnt == None:
         raise Exception("Cannot connect to BMR")
@@ -78,9 +101,9 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 
 
 class Bmr(ClimateEntity):
-
     def __init__(self, bmr, config):
         import pybmr
+
         self._circuit_id = config.get(ROOM)
         self._floor_circuit_id = config.get(FLOOR)
         self._schedule_mode_id = config.get(SCH_MODE_ID)
@@ -99,7 +122,6 @@ class Bmr(ClimateEntity):
         self._unit = "Status"
         self._icon = "mdi:restart"
         self.update()
-
 
     @property
     def should_poll(self):
@@ -124,17 +146,17 @@ class Bmr(ClimateEntity):
     @property
     def name(self):
         if self._channel_name != None:
-            return '{}'.format(self._channel_name)
+            return "{}".format(self._channel_name)
         else:
-            return '{}'.format(self._name)
+            return "{}".format(self._name)
 
     @property
     def device_state_attributes(self):
         attributes = {}
-        attributes['current_floor_temp'] = self._current_floor_temperature
-        attributes['max_allowed_floor_temperature'] = self._max_allowed_floor_temperature
-        attributes['heating'] = None if self._heating == 0 else self._heating
-        attributes['warning'] = self._warning
+        attributes["current_floor_temp"] = self._current_floor_temperature
+        attributes["max_allowed_floor_temperature"] = self._max_allowed_floor_temperature
+        attributes["heating"] = None if self._heating == 0 else self._heating
+        attributes["warning"] = self._warning
         return attributes
 
     @property
@@ -152,11 +174,11 @@ class Bmr(ClimateEntity):
     @property
     def hvac_mode(self):
         return self._current_hvac_mode
-    
+
     @property
     def hvac_action(self):
         return self._current_hvac_action
-    
+
     @property
     def current_temperature(self):
         return float(self._current_temperature)
@@ -184,26 +206,26 @@ class Bmr(ClimateEntity):
         if self._circuit_id != None:
             room_status = self._bmr.getStatus(self._circuit_id)
 
-        self._name = self.atLeastRoom(room_status, floor_status, 'name')
-        self._warning = self.atLeastRoom(room_status, floor_status, 'warning') #room or floor, any returns warning
+        self._name = self.atLeastRoom(room_status, floor_status, "name")
+        self._warning = self.atLeastRoom(room_status, floor_status, "warning")  # room or floor, any returns warning
 
         if room_status:
-            self._current_temperature = room_status['current_temp']
-            self._target_temperature = room_status['required_temp']
+            self._current_temperature = room_status["current_temp"]
+            self._target_temperature = room_status["required_temp"]
         if floor_status:
-            self._current_floor_temperature = floor_status['current_temp']
-            self._max_allowed_floor_temperature = floor_status['required_temp']
+            self._current_floor_temperature = floor_status["current_temp"]
+            self._max_allowed_floor_temperature = floor_status["required_temp"]
 
-        summer = self.atLeastRoom(room_status, floor_status, 'summer')
-        cooling = self.atLeastRoom(room_status, floor_status, 'cooling')
-        self._heating = self.bothRoomFloorHeating(room_status, floor_status, 'heating')
+        summer = self.atLeastRoom(room_status, floor_status, "summer")
+        cooling = self.atLeastRoom(room_status, floor_status, "cooling")
+        self._heating = self.bothRoomFloorHeating(room_status, floor_status, "heating")
         self.resolveActionModeIcon(summer, cooling, self._heating)
 
         # Ensure required attributes are filled
         if self._current_temperature == None:
-            self._current_temperature = self.atLeastRoom(room_status, floor_status, 'current_temp')
+            self._current_temperature = self.atLeastRoom(room_status, floor_status, "current_temp")
         if self._target_temperature == None:
-            self._target_temperature = self.atLeastRoom(room_status, floor_status, 'required_temp')
+            self._target_temperature = self.atLeastRoom(room_status, floor_status, "required_temp")
 
         if not room_status and not floor_status:
             self._warning = BMR_WARN_CANNOTCONNECT
@@ -216,9 +238,8 @@ class Bmr(ClimateEntity):
             self._current_hvac_action = None
             self._icon = "mdi:null"
 
-
     def resolveActionModeIcon(self, summer, cooling, heating):
-        #_LOGGER.debug("BMR status in manual update {}".format(status))
+        # _LOGGER.debug("BMR status in manual update {}".format(status))
         if summer == 0 and cooling == 0 and heating == 0:
             self._current_hvac_action = CURRENT_HVAC_IDLE
             self._current_hvac_mode = self.resolve_auto_mode()
@@ -231,7 +252,7 @@ class Bmr(ClimateEntity):
             self._current_hvac_action = CURRENT_HVAC_OFF
             self._current_hvac_mode = HVAC_MODE_OFF
             self._icon = "mdi:white-balance-sunny"
-        if heating == 2: # both room and floor want to heat
+        if heating == 2:  # both room and floor want to heat
             self._current_hvac_action = CURRENT_HVAC_HEAT
             self._current_hvac_mode = self.resolve_auto_mode()
             self._icon = "mdi:radiator"
@@ -252,26 +273,24 @@ class Bmr(ClimateEntity):
             if floor and floor[name]:
                 return floor[name]
             else:
-                return 0 # should not get here, 0 does not work just for status['name']
-
+                return 0  # should not get here, 0 does not work just for status['name']
 
     def resolve_auto_mode(self):
         mode = self._bmr.get_mode_id(self._circuit_id)
-        #_LOGGER.debug("BMR resolve mode for {} is {} (ai {} / sch {})".format(self._circuit_id, mode, self._ai_mode_id, self._schedule_mode_id))
+        # _LOGGER.debug("BMR resolve mode for {} is {} (ai {} / sch {})".format(self._circuit_id, mode, self._ai_mode_id, self._schedule_mode_id))
         if mode == self._ai_mode_id:
-             return HVAC_MODE_AUTO
+            return HVAC_MODE_AUTO
         elif mode == self._schedule_mode_id:
-             return HVAC_MODE_HEAT_COOL
+            return HVAC_MODE_HEAT_COOL
         else:
             return None
 
-
     def set_hvac_mode(self, hvac_mode):
-        if hvac_mode == HVAC_MODE_AUTO: # ai script
+        if hvac_mode == HVAC_MODE_AUTO:  # ai script
             self._bmr.set_mode_id(self._circuit_id, self._ai_mode_id)
             self._bmr.exclude_from_summer([self._floor_circuit_id, self._circuit_id])
             self._bmr.exclude_from_low([self._floor_circuit_id, self._circuit_id])
-        elif hvac_mode == HVAC_MODE_HEAT_COOL: # schedule
+        elif hvac_mode == HVAC_MODE_HEAT_COOL:  # schedule
             self._bmr.set_mode_id(self._circuit_id, self._schedule_mode_id)
             self._bmr.exclude_from_summer([self._floor_circuit_id, self._circuit_id])
             self._bmr.exclude_from_low([self._floor_circuit_id, self._circuit_id])
@@ -294,10 +313,10 @@ class Bmr(ClimateEntity):
         temperature = kwargs.get(ATTR_TEMPERATURE)
         if temperature is None:
             return
-        elif(temperature >= 10 and temperature<= 27):
+        elif temperature >= 10 and temperature <= 27:
             self._bmr.setTargetTemperature(temperature, self._ai_mode_id, self.name)
             self.manualUpdate()
         else:
-            _LOGGER.warn("Chosen temperature=%s is incorrect. It needs to be between 10 and 27.", str(temperature))
-
-
+            _LOGGER.warn(
+                "Chosen temperature=%s is incorrect. It needs to be between 10 and 27.", str(temperature),
+            )

--- a/custom_components/bmr/climate.py
+++ b/custom_components/bmr/climate.py
@@ -182,6 +182,8 @@ class BmrRoomClimate(ClimateEntity):
         self._min_temperature = min_temperature
         self._max_temperature = max_temperature
 
+        self._unique_id = f"{self._bmr.getUniqueId()}-climate-{self._config.get(CONF_CIRCUIT_ID)}"
+
         # Initial state
         self._circuit = {}
         self._schedule = {}
@@ -194,6 +196,12 @@ class BmrRoomClimate(ClimateEntity):
         """ Return the name of the climate entity.
         """
         return f"BMR HC64 {self._config.get(CONF_NAME)}"
+
+    @property
+    def unique_id(self):
+        """ Return unique ID of the entity.
+        """
+        return self._unique_id
 
     @property
     def temperature_unit(self):

--- a/custom_components/bmr/climate.py
+++ b/custom_components/bmr/climate.py
@@ -3,320 +3,372 @@ Support for BMR HC64 Heating Regulation.
 
 configuration.yaml
 
-climate:
-  - platform: bmr
-    host: ip
-    user: user
-    password: password
+  climate:
+    - platform: bmr
+      base_url: http://192.168.1.254/
+      username: !secret bmr_username
+      password: !secret bmr_password
+      away_temperature: 18.0
+      circuits:
+        - name: Kitchen
+          circuit: 8
+          schedule:
+            day_schedules: [1]
+            starting_day: 1
+          schedule_override: 16
 """
 
-__version__ = "1.0"
+__version__ = "0.7"
 
 import logging
-import json
-import voluptuous as vol
-import re
-
+import socket
 from datetime import timedelta
+
+import voluptuous as vol
+
 
 from homeassistant.components.climate import ClimateEntity, PLATFORM_SCHEMA
 from homeassistant.components.climate.const import (
-    SUPPORT_TARGET_TEMPERATURE,
-    ATTR_HVAC_MODE,
-    HVAC_MODE_OFF,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-    HVAC_MODE_HEAT_COOL,
-    CURRENT_HVAC_OFF,
-    CURRENT_HVAC_HEAT,
     CURRENT_HVAC_COOL,
+    CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
+    CURRENT_HVAC_OFF,
+    HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT,
+    HVAC_MODE_HEAT_COOL,
+    HVAC_MODE_OFF,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
 )
 
 from homeassistant.const import (
-    STATE_ON,
-    STATE_OFF,
-    CONF_NAME,
-    CONF_HOST,
-    CONF_USERNAME,
-    CONF_PASSWORD,
-    TEMP_CELSIUS,
     ATTR_TEMPERATURE,
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    TEMP_CELSIUS,
 )
 import homeassistant.helpers.config_validation as cv
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle as throttle
 
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
-SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE
+PRESET_NORMAL = "Normal"
+PRESET_AWAY = "Away"
+
+TEMP_MIN = 7.0
+TEMP_MAX = 35.0
+
 _LOGGER = logging.getLogger(__name__)
-# DEFAULT_NAME = "BMR"
-# STATE_MANUAL = 'manual'
-# STATE_UNKNOWN = 'unknown'
-BMR_WARN_CANNOTCONNECT = 9
-HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_AUTO, HVAC_MODE_HEAT_COOL]
 
-CHANNELS = "honza"
-NAME = "name"
-SCH_MODE_ID = "schedule_mode_id"
-AI_MODE_ID = "ai_mode_id"
-FLOOR = "floor"
-ROOM = "room"
+CONF_BASE_URL = "base_url"
+CONF_CIRCUITS = "circuits"
+CONF_NAME = "name"
+CONF_CIRCUIT_ID = "circuit"
+CONF_SCHEDULE = "schedule"
+CONF_DAY_SCHEDULES = "day_schedules"
+CONF_STARTING_DAY = "starting_day"
+CONF_SCHEDULE_OVERRIDE = "schedule_override"
+CONF_AWAY_TEMPERATURE = "away_temperature"
+CONF_CAN_COOL = "can_cool"
 
-CHANNEL_SCHEMA = vol.Schema(
+CONF_CIRCUIT = vol.Schema(
     {
-        vol.Required(NAME): cv.string,
-        vol.Optional(SCH_MODE_ID): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
-        vol.Optional(AI_MODE_ID): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
-        vol.Optional(FLOOR): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
-        vol.Optional(ROOM): vol.All(vol.Coerce(int), vol.Range(min=0, max=31)),
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_CIRCUIT_ID): vol.All(vol.Coerce(int), vol.Range(min=0, max=63)),
+        vol.Required(CONF_SCHEDULE): vol.Schema(
+            {
+                vol.Required(CONF_DAY_SCHEDULES): vol.All(
+                    cv.ensure_list, [vol.All(vol.Coerce(int), vol.Range(min=0, max=63))]
+                ),
+                vol.Optional(CONF_STARTING_DAY): vol.All(vol.Coerce(int), vol.Range(min=1, max=21)),
+            }
+        ),
+        vol.Required(CONF_SCHEDULE_OVERRIDE): vol.All(vol.Coerce(int), vol.Range(min=0, max=63)),
     }
 )
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_BASE_URL): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
-        vol.Required(CHANNELS): vol.All(cv.ensure_list, [CHANNEL_SCHEMA]),
+        vol.Optional(CONF_AWAY_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=TEMP_MIN, max=TEMP_MAX)),
+        vol.Optional(CONF_CAN_COOL): vol.Coerce(bool),
+        vol.Required(CONF_CIRCUITS): vol.All(cv.ensure_list, [CONF_CIRCUIT]),
     }
 )
 
 
-def setup_platform(hass, config, add_devices, discovery_info=None):
+def setup_platform(hass, config, add_entities, discovery_info=None):
     import pybmr
 
-    host = config.get(CONF_HOST)
+    base_url = config.get(CONF_BASE_URL)
     user = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    bmr = pybmr.Bmr(host, user, password)  # Test connectivity
-    cnt = bmr.getNumCircuits()
-    if cnt == None:
-        raise Exception("Cannot connect to BMR")
-
-    devices = []
-    for channel in config.get(CHANNELS):
-        devices.append(Bmr(bmr, CHANNEL_SCHEMA(channel)))
-    add_devices(devices)
+    bmr = pybmr.Bmr(base_url, user, password)
+    entities = [
+        BmrRoomClimate(bmr, circuit, config.get(CONF_AWAY_TEMPERATURE, 18.0), config.get(CONF_CAN_COOL, False),)
+        for circuit in config.get(CONF_CIRCUITS)
+    ]
+    add_entities(entities)
 
 
-class Bmr(ClimateEntity):
-    def __init__(self, bmr, config):
-        import pybmr
+class BmrRoomClimate(ClimateEntity):
+    """ Entity representing a room heated by the BMR HC64 controller unit.
 
-        self._circuit_id = config.get(ROOM)
-        self._floor_circuit_id = config.get(FLOOR)
-        self._schedule_mode_id = config.get(SCH_MODE_ID)
-        self._ai_mode_id = config.get(AI_MODE_ID)
+        Usually the room has two temperature sensors (circuits): floor and room
+        sensor.  The controller will heat the room if BOTH sensors report lower
+        current temperature then their target temperature.
+
+        For simplicity it is recommended to set the floor sensor to a fixed
+        temperature that is almost always higher than the actual floor
+        temperature (e.g. 32 degrees) so that the floor sensor always "wants"
+        to heat the room. This way the room temperature can be easily
+        controlled just by the room sensor.
+
+        This HA entity takes advantage of this approach. It will only modify
+        settings related to the room cirtuit and will not touch settings of the
+        floor circuit. It is up to the user to configure the floor circuit
+        using the HC64 web UI.
+
+        This class supports the following HVAC modes:
+
+        - HVAC_MODE_AUTO - Automatic mode. HC64 controller will manage the
+          temperature automatically according to its configuration.
+
+        - HVAC_MODE_HEAT/HVAC_MODE_HEAT_COOL - Override the target temperature
+          manually. Useful for temporarily increase/decrease the target
+          temperature in the room.  Note that this will switch the circuit to a
+          special "override" schedule and configure this schedule with the
+          target temperature. HVAC_MODE_HEAT_COOL is for water-based circuits
+          that can also cool.
+
+        - HVAC_MODE_OFF - Turn off the heating circuit by assigning it to
+          "summer mode" and turning the summer mode on.
+
+          NOTE: Make sure to remove all circuits from summer mode when using
+          the plugin for the first time. Otherwise any circuits assigned to the
+          summer mode will be also turned off when the user switches a
+          circuit into the HVAC_MODE_OFF mode.
+
+          NOTE #2: The HC64 controller is slow AF so updates after changing
+          something (such as HVAC mode) may take a while to show in Home
+          Assistant UI. Even several minutes.
+      """
+
+    def __init__(self, bmr, config, away_temperature=18.0, can_cool=False):
         self._bmr = bmr
-        self._heating = 0
-        self._warning = None
-        self._name = None
-        self._channel_name = config.get(NAME)
-        self._current_temperature = None
-        self._target_temperature = None
-        self._max_allowed_floor_temperature = None
-        self._current_floor_temperature = None
-        self._current_hvac_mode = None
-        self._current_hvac_action = None
-        self._unit = "Status"
-        self._icon = "mdi:restart"
-        self.update()
+        self._config = config
+        self._away_temperature = away_temperature
+        self._can_cool = can_cool
 
-    @property
-    def should_poll(self):
-        return True
-
-    @property
-    def unit_of_measurement(self):
-        return self._unit
-
-    @property
-    def icon(self):
-        return self._icon
-
-    @property
-    def state(self):
-        return self._current_hvac_mode
-
-    @property
-    def supported_features(self):
-        return SUPPORT_FLAGS
+        # Initial state
+        self._circuit = {}
+        self._schedule = {}
+        self._low_mode = {}
+        self._summer_mode = None
+        self._summer_mode_assignments = []
 
     @property
     def name(self):
-        if self._channel_name != None:
-            return "{}".format(self._channel_name)
-        else:
-            return "{}".format(self._name)
-
-    @property
-    def device_state_attributes(self):
-        attributes = {}
-        attributes["current_floor_temp"] = self._current_floor_temperature
-        attributes["max_allowed_floor_temperature"] = self._max_allowed_floor_temperature
-        attributes["heating"] = None if self._heating == 0 else self._heating
-        attributes["warning"] = self._warning
-        return attributes
+        """ Return the name of the climate entity.
+        """
+        return f"BMR HC64 {self._config.get(CONF_NAME)}"
 
     @property
     def temperature_unit(self):
+        """ The unit of temperature measurement for the system.
+        """
         return TEMP_CELSIUS
 
     @property
-    def target_temperature(self):
-        return float(self._target_temperature)
-
-    @property
-    def hvac_modes(self):
-        return HVAC_MODES
-
-    @property
-    def hvac_mode(self):
-        return self._current_hvac_mode
-
-    @property
-    def hvac_action(self):
-        return self._current_hvac_action
-
-    @property
     def current_temperature(self):
-        return float(self._current_temperature)
+        """ Current temperature.
+        """
+        return self._circuit.get("temperature")
+
+    @property
+    def target_temperature(self):
+        """ Currently set target temperature.
+        """
+        return self._circuit.get("target_temperature")
 
     @property
     def min_temp(self):
-        return 10
+        return TEMP_MIN
 
     @property
     def max_temp(self):
-        return 27
+        return TEMP_MAX
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
-    def update(self):
-        self.manualUpdate()
+    @property
+    def hvac_modes(self):
+        """ Supported HVAC modes.
 
-    def manualUpdate(self):
-        self._warning = None
-        room_status = None
-        floor_status = None
-
-        if self._floor_circuit_id != None:
-            floor_status = self._bmr.getStatus(self._floor_circuit_id)
-
-        if self._circuit_id != None:
-            room_status = self._bmr.getStatus(self._circuit_id)
-
-        self._name = self.atLeastRoom(room_status, floor_status, "name")
-        self._warning = self.atLeastRoom(room_status, floor_status, "warning")  # room or floor, any returns warning
-
-        if room_status:
-            self._current_temperature = room_status["current_temp"]
-            self._target_temperature = room_status["required_temp"]
-        if floor_status:
-            self._current_floor_temperature = floor_status["current_temp"]
-            self._max_allowed_floor_temperature = floor_status["required_temp"]
-
-        summer = self.atLeastRoom(room_status, floor_status, "summer")
-        cooling = self.atLeastRoom(room_status, floor_status, "cooling")
-        self._heating = self.bothRoomFloorHeating(room_status, floor_status, "heating")
-        self.resolveActionModeIcon(summer, cooling, self._heating)
-
-        # Ensure required attributes are filled
-        if self._current_temperature == None:
-            self._current_temperature = self.atLeastRoom(room_status, floor_status, "current_temp")
-        if self._target_temperature == None:
-            self._target_temperature = self.atLeastRoom(room_status, floor_status, "required_temp")
-
-        if not room_status and not floor_status:
-            self._warning = BMR_WARN_CANNOTCONNECT
-            self._heating = 0
-            self._current_temperature = None
-            self._target_temperature = None
-            self._max_allowed_floor_temperature = None
-            self._current_floor_temperature = None
-            self._current_hvac_mode = None
-            self._current_hvac_action = None
-            self._icon = "mdi:null"
-
-    def resolveActionModeIcon(self, summer, cooling, heating):
-        # _LOGGER.debug("BMR status in manual update {}".format(status))
-        if summer == 0 and cooling == 0 and heating == 0:
-            self._current_hvac_action = CURRENT_HVAC_IDLE
-            self._current_hvac_mode = self.resolve_auto_mode()
-            self._icon = "mdi:sleep"
-        if summer == 0 and cooling == 1 and heating == 0:
-            self._current_hvac_action = CURRENT_HVAC_COOL
-            self._current_hvac_mode = HVAC_MODE_COOL
-            self._icon = "mdi:snowflake"
-        if summer == 1 and heating == 0:
-            self._current_hvac_action = CURRENT_HVAC_OFF
-            self._current_hvac_mode = HVAC_MODE_OFF
-            self._icon = "mdi:white-balance-sunny"
-        if heating == 2:  # both room and floor want to heat
-            self._current_hvac_action = CURRENT_HVAC_HEAT
-            self._current_hvac_mode = self.resolve_auto_mode()
-            self._icon = "mdi:radiator"
-
-    def bothRoomFloorHeating(self, room, floor, name):
-        r = 1
-        f = 1
-        if room and room[name] == 0:
-            r = 0
-        if floor and floor[name] == 0:
-            f = 0
-        return r + f
-
-    def atLeastRoom(self, room, floor, name):
-        if room and room[name]:
-            return room[name]
+        See docs: https://developers.home-assistant.io/docs/core/entity/climate/#hvac-modes
+        """
+        if self._can_cool:
+            return [HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_HEAT_COOL]
         else:
-            if floor and floor[name]:
-                return floor[name]
+            return [HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_HEAT]
+
+    @property
+    def hvac_mode(self):
+        """ Current HVAC mode.
+
+            Return HVAC_MODE_OFF if the summer mode for the circuit is turned
+            on. Summer mode essentially means the circuit is turned off.
+
+            Return HVAC_MODE_HEAT/HVAC_MODE_HEAT_COOL if the user manually
+            overrode the target temperature. The override works by reassigning
+            the circuit to a special "override" schedule specified in the
+            configuration. The target temperature for the "override" schedule
+            is set by the set_temperature() method.
+
+            Return HVAC_MODE_AUTO if the controller is managing everything
+            automatically according to its configuration.
+        """
+        if (
+            self._summer_mode
+            and self._summer_mode_assignments
+            and self._summer_mode_assignments[self._config.get(CONF_CIRCUIT_ID)]
+        ):
+            return HVAC_MODE_OFF
+        elif [self._config.get(CONF_SCHEDULE_OVERRIDE)] == self._schedule.get("day_schedules"):
+            if self._can_cool:
+                return HVAC_MODE_HEAT_COOL
             else:
-                return 0  # should not get here, 0 does not work just for status['name']
-
-    def resolve_auto_mode(self):
-        mode = self._bmr.get_mode_id(self._circuit_id)
-        # _LOGGER.debug("BMR resolve mode for {} is {} (ai {} / sch {})".format(self._circuit_id, mode, self._ai_mode_id, self._schedule_mode_id))
-        if mode == self._ai_mode_id:
-            return HVAC_MODE_AUTO
-        elif mode == self._schedule_mode_id:
-            return HVAC_MODE_HEAT_COOL
+                return HVAC_MODE_HEAT
         else:
-            return None
+            # The controller is managing everything automatically according to
+            # configured schedules.
+            return HVAC_MODE_AUTO
 
     def set_hvac_mode(self, hvac_mode):
-        if hvac_mode == HVAC_MODE_AUTO:  # ai script
-            self._bmr.set_mode_id(self._circuit_id, self._ai_mode_id)
-            self._bmr.exclude_from_summer([self._floor_circuit_id, self._circuit_id])
-            self._bmr.exclude_from_low([self._floor_circuit_id, self._circuit_id])
-        elif hvac_mode == HVAC_MODE_HEAT_COOL:  # schedule
-            self._bmr.set_mode_id(self._circuit_id, self._schedule_mode_id)
-            self._bmr.exclude_from_summer([self._floor_circuit_id, self._circuit_id])
-            self._bmr.exclude_from_low([self._floor_circuit_id, self._circuit_id])
-        elif hvac_mode == HVAC_MODE_OFF:
-            self._bmr.include_to_summer([self._floor_circuit_id, self._circuit_id])
-        elif hvac_mode == HVAC_MODE_COOL:
-            self._bmr.exclude_from_summer([self._floor_circuit_id, self._circuit_id])
-            self._bmr.include_to_low([self._floor_circuit_id, self._circuit_id])
+        """ Set HVAC mode.
+        """
+        if hvac_mode == HVAC_MODE_OFF:
+            # Turn on the HVAC_MODE_OFF. This will turn off the heating/cooling
+            # of the given circuit. This works by:
+            #
+            # - Adding the circuit to summer mode
+            # - Turning the summer mode ON
+            #
+            # NOTE: Sometimes (usually) there are also other circuits assigned
+            # to summer mode, especially if this plugin is used for the first
+            # time. If there are also other circutis assigned to summer mode
+            # and summer mode is turned on they will be turned off too. Make
+            # sure to remove any circuits from the summer mode manually when
+            # using the plugin for the first time.
+            self._bmr.setSummerModeAssignments([self._config.get(CONF_CIRCUIT_ID)], True)
+            self._bmr.setSummerMode(True)
         else:
-            _LOGGER.warn("Unsupported HVAC mode {} for {}".format(hvac_mode, self._channel_name))
-        self.manualUpdate()
+            # Turn HVAC_MODE_OFF off and restore normal operation.
+            #
+            # - Remove the circuit from the summer mode assignments
+            # - If there aren't any circuits assigned to summer mode anymore
+            #   turn the summer mode OFF.
+            self._bmr.setSummerModeAssignments([self._config.get(CONF_CIRCUIT_ID)], False)
+            if not any(self._bmr.getSummerModeAssignments()):
+                self._bmr.setSummerMode(False)
 
-    def set_temperature(self, **kwargs):
-        """Set new target temperature."""
-        # check if room is set to auto mode
-        if self._ai_mode_id == None or self._current_hvac_mode != HVAC_MODE_AUTO:
-            _LOGGER.warn("Temperature cannot be set if BMR room is not set to AUTO")
+        if hvac_mode in (HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL):
+            # Turn on the HVAC_MODE_HEAT. This will assign the "override"
+            # schedule to the circuit. The "override" schedule is used for
+            # setting the custom target temperature (see set_temperature()
+            # below).
+            self._bmr.setCircuitSchedules(
+                self._config.get(CONF_CIRCUIT_ID), [self._config.get(CONF_SCHEDULE_OVERRIDE)],
+            )
+        else:
+            # Turn off the HVAC_MODE_HEAT/HVAC_MODE_HEAT_COOL and restore
+            # normal operation.
+            #
+            # - Assign normal schedules to the circuit
+            self._bmr.setCircuitSchedules(
+                self._config.get(CONF_CIRCUIT_ID),
+                self._config.get(CONF_SCHEDULE)[CONF_DAY_SCHEDULES],
+                self._config.get(CONF_SCHEDULE).get(CONF_STARTING_DAY, 1),
+            )
+
+        if hvac_mode == HVAC_MODE_AUTO:
+            # Turn on the HVAC_MODE_AUTO. Currently this is no-op, as the
+            # normal operation is restored in the else branches above.
             pass
 
-        temperature = kwargs.get(ATTR_TEMPERATURE)
-        if temperature is None:
-            return
-        elif temperature >= 10 and temperature <= 27:
-            self._bmr.setTargetTemperature(temperature, self._ai_mode_id, self.name)
-            self.manualUpdate()
+    @property
+    def hvac_action(self):
+        """ What is the climate device currently doing (cooling, heating, idle).
+        """
+        if (
+            self._summer_mode
+            and self._summer_mode_assignments
+            and self._summer_mode_assignments[self._config.get(CONF_CIRCUIT_ID)]
+        ):
+            return CURRENT_HVAC_OFF
+        elif self._circuit.get("heating"):
+            return CURRENT_HVAC_HEAT
+        elif self._circuit.get("cooling"):
+            return CURRENT_HVAC_COOL
         else:
-            _LOGGER.warn(
-                "Chosen temperature=%s is incorrect. It needs to be between 10 and 27.", str(temperature),
-            )
+            return CURRENT_HVAC_IDLE
+
+    @property
+    def preset_modes(self):
+        """ Supported preset modes.
+        """
+        return [PRESET_NORMAL, PRESET_AWAY]
+
+    @property
+    def preset_mode(self):
+        """ Current preset mode.
+        """
+        if self._low_mode.get("enabled"):
+            return PRESET_AWAY
+        else:
+            return PRESET_NORMAL
+
+    def set_preset_mode(self, preset_mode):
+        """ Set preset mode.
+        """
+        if preset_mode == PRESET_AWAY:
+            self._bmr.setLowMode(True, self._away_temperature)
+        else:
+            self._bmr.setLowMode(False)
+
+    @property
+    def supported_features(self):
+        """ Supported features
+        """
+        return SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
+
+    def set_temperature(self, **kwargs):
+        """ Set new target temperature for the circuit. This works by
+            modifying the special "override" schedule and assigning the
+            schedule to the circuit. This is done to avoid overwriting the
+            normal schedule that is used for HVAC_MODE_AUTO.
+        """
+        temperature = kwargs.get(ATTR_TEMPERATURE)
+        self._bmr.setSchedule(
+            self._config.get(CONF_SCHEDULE_OVERRIDE),
+            f"{self._config.get(CONF_NAME)} override",
+            [{"time": "00:00", "temperature": temperature}],
+        )
+        if self.hvac_mode not in (HVAC_MODE_HEAT, HVAC_MODE_HEAT_COOL):
+            if self._can_cool:
+                self.set_hvac_mode(HVAC_MODE_HEAT_COOL)
+            else:
+                self.set_hvac_mode(HVAC_MODE_HEAT)
+
+    @throttle(timedelta(seconds=30))
+    def update(self):
+        """ Fetch new state data for the controller. This is the only method
+            that should fetch new data for Home Assistant.
+        """
+        try:
+            self._circuit = self._bmr.getCircuit(self._config.get(CONF_CIRCUIT_ID))
+            self._schedule = self._bmr.getCircuitSchedules(self._config.get(CONF_CIRCUIT_ID))
+            self._low_mode = self._bmr.getLowMode()
+            self._summer_mode = self._bmr.getSummerMode()
+            self._summer_mode_assignments = self._bmr.getSummerModeAssignments()
+        except socket.timeout:
+            _LOGGER.warn("Read from BMR HC64 controller timed out. Retrying later.")

--- a/custom_components/bmr/manifest.json
+++ b/custom_components/bmr/manifest.json
@@ -4,5 +4,5 @@
     "documentation": "https://github.com/slesinger/HomeAssistant-BMR",
     "dependencies": [],
     "codeowners": ["@slesinger"],
-    "requirements": ["pybmr==0.6"]
+    "requirements": ["pybmr==0.7"]
   }

--- a/custom_components/bmr/manifest.json
+++ b/custom_components/bmr/manifest.json
@@ -1,6 +1,6 @@
 {
-    "domain": "bmr",
-    "name": "BMR",
+    "domain": "bmr_hc64",
+    "name": "BMR HC64",
     "documentation": "https://github.com/slesinger/HomeAssistant-BMR",
     "dependencies": [],
     "codeowners": ["@slesinger"],

--- a/custom_components/bmr/sensor.py
+++ b/custom_components/bmr/sensor.py
@@ -31,7 +31,6 @@ from homeassistant.util import Throttle
 
 MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
 _LOGGER = logging.getLogger(__name__)
-HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_AUTO]
 
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
@@ -69,8 +68,6 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
 
 class BmrCommon(Entity):
     def __init__(self, bmr):
-        import pybmr
-
         self._bmr = bmr
         self._icon = "mdi:restart"
         self._current_hvac_mode = None

--- a/custom_components/bmr/sensor.py
+++ b/custom_components/bmr/sensor.py
@@ -5,39 +5,48 @@ configuration.yaml
 
 sensor:
   - platform: bmr
-    host: ip
+    base_url: http://ip-address/
     user: user
     password: password
+    circuits:
+        - circuit: 0
+          name: Kitchen
+        - circuit: 1
+          name: Living room
 """
 
-_version__ = "1.0"
+__version__ = "0.7"
 
-from datetime import timedelta
 import logging
+import socket
+from datetime import timedelta
 
-import voluptuous as vol
-
-from homeassistant.components.sensor import PLATFORM_SCHEMA
-
-from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
-from homeassistant.components.climate.const import (
-    HVAC_MODE_OFF,
-    HVAC_MODE_AUTO,
-    HVAC_MODE_COOL,
-)
 import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant.components.sensor import PLATFORM_SCHEMA
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, TEMP_CELSIUS
 from homeassistant.helpers.entity import Entity
-from homeassistant.util import Throttle
+from homeassistant.util import Throttle as throttle
 
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=60)
 _LOGGER = logging.getLogger(__name__)
 
+CONF_BASE_URL = "base_url"
+CONF_CIRCUITS = "circuits"
+CONF_NAME = "name"
+CONF_CIRCUIT_ID = "circuit"
+CONF_CIRCUIT = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_CIRCUIT_ID): vol.All(vol.Coerce(int), vol.Range(min=0, max=63)),
+    }
+)
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
-        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_BASE_URL): cv.string,
         vol.Required(CONF_USERNAME): cv.string,
         vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_CIRCUITS): vol.All(cv.ensure_list, [CONF_CIRCUIT]),
     }
 )
 
@@ -45,94 +54,94 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 def setup_platform(hass, config, add_entities, discovery_info=None):
     import pybmr
 
-    host = config.get(CONF_HOST)
+    base_url = config.get(CONF_BASE_URL)
     user = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    bmr = pybmr.Bmr(host, user, password)  # Test connectivity
-    cnt = bmr.getNumCircuits()
-    if cnt == None:
-        raise Exception("Cannot connect to BMR")
+    bmr = pybmr.Bmr(base_url, user, password)
+    num_circuits = bmr.getNumCircuits()
     sensors = []
-    bmr_common = BmrCommon(bmr)
-    sensors.append(bmr_common)
+    for circuit_config in config.get(CONF_CIRCUITS):
+        if circuit_config.get(CONF_CIRCUIT_ID) < num_circuits:
+            sensors.append(BmrCircuitTemperature(bmr, circuit_config))
+            sensors.append(BmrCircuitTargetTemperature(bmr, circuit_config))
+        else:
+            _LOGGER.warn(f"Circuit ID {circuit_config.get(CONF_CIRCUIT_ID)} is out of range")
+
     add_entities(sensors)
 
-    def handle_event(event):
-        if event.data["entity_id"] == "input_select.bmr_rezim":
-            state = event.data["new_state"].as_dict()["state"]
-            bmr_common.set_hvac_mode(state)
 
-    hass.bus.listen("state_changed", handle_event)
+class BmrCircuitTemperatureBase(Entity):
+    """ Base class for temperature reporting sensors.
+    """
 
-
-class BmrCommon(Entity):
-    def __init__(self, bmr):
+    def __init__(self, bmr, config):
         self._bmr = bmr
-        self._icon = "mdi:restart"
-        self._current_hvac_mode = None
-        self.update()
+        self._config = config
+
+        self._circuit = {}
 
     @property
-    def should_poll(self):
-        return True
+    def unit_of_measurement(self):
+        """ Return the unit of measurement.
+        """
+        return TEMP_CELSIUS
+
+    @property
+    def device_state_attributes(self):
+        return {
+            "enabled": self._circuit.get("enabled"),
+            "user_offset": self._circuit.get("user_offset"),
+            "max_offset": self._circuit.get("max_offset"),
+            "warning": self._circuit.get("warning"),
+            "heating": self._circuit.get("heating"),
+            "cooling": self._circuit.get("cooling"),
+            "low_mode": self._circuit.get("low_mode"),
+            "summer_mode": self._circuit.get("summer_mode"),
+            "temperature": self._circuit.get("temperature"),
+            "target_temperature": self._circuit.get("target_temperature"),
+        }
+
+    @throttle(timedelta(seconds=30))
+    def update(self):
+        """ Fetch new state data for the sensor.
+            This is the only method that should fetch new data for Home Assistant.
+        """
+        try:
+            self._circuit = self._bmr.getCircuit(self._config.get(CONF_CIRCUIT_ID))
+        except socket.timeout:
+            _LOGGER.warn("Read from BMR HC64 controller timed out. Retrying later.")
+
+
+class BmrCircuitTemperature(BmrCircuitTemperatureBase):
+    """ Sensor for reporting the current temperature in BMR HC64 heating circuit.
+    """
 
     @property
     def name(self):
-        return "Rezimy BMR Regulatoru"
-
-    @property
-    def icon(self):
-        return self._icon
+        """ Return the name of the sensor.
+        """
+        return f"BMR HC64 {self._config.get(CONF_NAME)} temperature"
 
     @property
     def state(self):
-        return self._current_hvac_mode
+        """ Return the state of the sensor.
+        """
+        return self._circuit.get("temperature")
 
-    @Throttle(MIN_TIME_BETWEEN_SCANS)
-    def update(self):
-        self.manualUpdate()
 
-    def manualUpdate(self):
-        is_summer = self._bmr.loadSummerMode()
-        is_low = self._bmr.loadLows()
-        if is_summer == True:
-            self._current_hvac_mode = HVAC_MODE_OFF
-            self._icon = "mdi:radiator-off"
-            return
-        elif is_summer == False and is_low == True:
-            self._current_hvac_mode = HVAC_MODE_COOL
-            self._icon = "mdi:snowflake"
-            return
-        elif is_summer == False and is_low == False:
-            self._current_hvac_mode = HVAC_MODE_AUTO
-            self._icon = "mdi:brightness-auto"
-            return
-        else:
-            self._current_hvac_mode = None
-            self._icon = "mdi:help"
-            return
+class BmrCircuitTargetTemperature(BmrCircuitTemperatureBase):
+    """ Sensor for reporting the current temperature in BMR HC64 heating circuit.
+    """
 
-    def set_hvac_mode(self, hvac_mode):
+    @property
+    def name(self):
+        """ Return the name of the sensor.
+        """
+        return f"BMR HC64 {self._config.get(CONF_NAME)} target temperature"
 
-        if hvac_mode == "auto":
-            hvac_mode = HVAC_MODE_AUTO
-        if hvac_mode == "rozvrh":
-            hvac_mode = HVAC_MODE_AUTO
-        if hvac_mode == "utlum":
-            hvac_mode = HVAC_MODE_COOL
-        if hvac_mode == "vypnuto":
-            hvac_mode = HVAC_MODE_OFF
-
-        if hvac_mode == HVAC_MODE_AUTO:  # summer off, low off
-            self._bmr.saveSummerMode(False)
-            self._bmr.lowSave(False)
-        elif hvac_mode == HVAC_MODE_OFF:
-            self._bmr.saveSummerMode(True)
-            self._bmr.lowSave(True)
-        elif hvac_mode == HVAC_MODE_COOL:
-            self._bmr.saveSummerMode(False)
-            self._bmr.lowSave(True)
-        else:
-            _LOGGER.warn("Unsupported HVAC mode {}".format(hvac_mode))
-        self.manualUpdate()
+    @property
+    def state(self):
+        """ Return the state of the sensor.
+        """
+        return self._circuit.get("target_temperature")

--- a/custom_components/bmr/sensor.py
+++ b/custom_components/bmr/sensor.py
@@ -117,11 +117,21 @@ class BmrCircuitTemperature(BmrCircuitTemperatureBase):
     """ Sensor for reporting the current temperature in BMR HC64 heating circuit.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._unique_id = f"{self._bmr.getUniqueId()}-sensor-{self._config.get(CONF_CIRCUIT_ID)}-temperature"
+
     @property
     def name(self):
         """ Return the name of the sensor.
         """
         return f"BMR HC64 {self._config.get(CONF_NAME)} temperature"
+
+    @property
+    def unique_id(self):
+        """ Return unique ID of the entity.
+        """
+        return self._unique_id
 
     @property
     def state(self):
@@ -134,11 +144,21 @@ class BmrCircuitTargetTemperature(BmrCircuitTemperatureBase):
     """ Sensor for reporting the current temperature in BMR HC64 heating circuit.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._unique_id = f"{self._bmr.getUniqueId()}-sensor-{self._config.get(CONF_CIRCUIT_ID)}-target-temperature"
+
     @property
     def name(self):
         """ Return the name of the sensor.
         """
         return f"BMR HC64 {self._config.get(CONF_NAME)} target temperature"
+
+    @property
+    def unique_id(self):
+        """ Return unique ID of the entity.
+        """
+        return self._unique_id
 
     @property
     def state(self):

--- a/custom_components/bmr/sensor.py
+++ b/custom_components/bmr/sensor.py
@@ -10,7 +10,7 @@ sensor:
     password: password
 """
 
-__version__ = "1.0"
+_version__ = "1.0"
 
 import logging
 import voluptuous as vol
@@ -19,8 +19,12 @@ from datetime import timedelta
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 
-from homeassistant.const import (CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD)
-from homeassistant.components.climate.const import (HVAC_MODE_OFF, HVAC_MODE_AUTO, HVAC_MODE_COOL)
+from homeassistant.const import CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.components.climate.const import (
+    HVAC_MODE_OFF,
+    HVAC_MODE_AUTO,
+    HVAC_MODE_COOL,
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.util import Throttle
@@ -30,20 +34,23 @@ _LOGGER = logging.getLogger(__name__)
 HVAC_MODES = [HVAC_MODE_OFF, HVAC_MODE_COOL, HVAC_MODE_AUTO]
 
 
-PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
-    vol.Required(CONF_HOST): cv.string,
-    vol.Required(CONF_USERNAME): cv.string,
-    vol.Required(CONF_PASSWORD): cv.string
-})
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+    }
+)
 
 
 def setup_platform(hass, config, add_entities, discovery_info=None):
     import pybmr
+
     host = config.get(CONF_HOST)
     user = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
 
-    bmr = pybmr.Bmr(host, user, password) # Test connectivity
+    bmr = pybmr.Bmr(host, user, password)  # Test connectivity
     cnt = bmr.getNumCircuits()
     if cnt == None:
         raise Exception("Cannot connect to BMR")
@@ -53,18 +60,17 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     add_entities(sensors)
 
     def handle_event(event):
-        if event.data['entity_id']== 'input_select.bmr_rezim':
-            state = event.data['new_state'].as_dict()['state']
+        if event.data["entity_id"] == "input_select.bmr_rezim":
+            state = event.data["new_state"].as_dict()["state"]
             bmr_common.set_hvac_mode(state)
 
-    hass.bus.listen('state_changed', handle_event)
-
+    hass.bus.listen("state_changed", handle_event)
 
 
 class BmrCommon(Entity):
-
     def __init__(self, bmr):
         import pybmr
+
         self._bmr = bmr
         self._icon = "mdi:restart"
         self._current_hvac_mode = None
@@ -76,12 +82,11 @@ class BmrCommon(Entity):
 
     @property
     def name(self):
-        return 'Rezimy BMR Regulatoru'
+        return "Rezimy BMR Regulatoru"
 
     @property
     def icon(self):
         return self._icon
-
 
     @property
     def state(self):
@@ -113,16 +118,16 @@ class BmrCommon(Entity):
 
     def set_hvac_mode(self, hvac_mode):
 
-        if hvac_mode == 'auto':
+        if hvac_mode == "auto":
             hvac_mode = HVAC_MODE_AUTO
-        if hvac_mode == 'rozvrh':
+        if hvac_mode == "rozvrh":
             hvac_mode = HVAC_MODE_AUTO
-        if hvac_mode == 'utlum':
+        if hvac_mode == "utlum":
             hvac_mode = HVAC_MODE_COOL
-        if hvac_mode == 'vypnuto':
+        if hvac_mode == "vypnuto":
             hvac_mode = HVAC_MODE_OFF
 
-        if hvac_mode == HVAC_MODE_AUTO: # summer off, low off
+        if hvac_mode == HVAC_MODE_AUTO:  # summer off, low off
             self._bmr.saveSummerMode(False)
             self._bmr.lowSave(False)
         elif hvac_mode == HVAC_MODE_OFF:
@@ -134,4 +139,3 @@ class BmrCommon(Entity):
         else:
             _LOGGER.warn("Unsupported HVAC mode {}".format(hvac_mode))
         self.manualUpdate()
-

--- a/custom_components/bmr/sensor.py
+++ b/custom_components/bmr/sensor.py
@@ -12,14 +12,14 @@ sensor:
 
 _version__ = "1.0"
 
-import logging
-import voluptuous as vol
-
 from datetime import timedelta
+import logging
+
+import voluptuous as vol
 
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 
-from homeassistant.const import CONF_NAME, CONF_HOST, CONF_USERNAME, CONF_PASSWORD
+from homeassistant.const import CONF_HOST, CONF_USERNAME, CONF_PASSWORD
 from homeassistant.components.climate.const import (
     HVAC_MODE_OFF,
     HVAC_MODE_AUTO,

--- a/custom_components/bmr/switch.py
+++ b/custom_components/bmr/switch.py
@@ -1,0 +1,177 @@
+"""
+Support for BMR HC64 Heating Regulation.
+
+configuration.yaml
+
+switch:
+  - platform: bmr
+    base_url: http://ip-address/
+    user: user
+    password: password
+    circuits:
+      - name: "Workshop"
+        circuit: 8
+
+      - name: "Storage"
+        circuit: 9
+"""
+
+__version__ = "0.7"
+
+import logging
+import socket
+from datetime import timedelta
+
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
+from homeassistant.components.switch import PLATFORM_SCHEMA, SwitchEntity
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.util import Throttle as throttle
+
+_LOGGER = logging.getLogger(__name__)
+
+CONF_BASE_URL = "base_url"
+CONF_CIRCUITS = "circuits"
+CONF_NAME = "name"
+CONF_CIRCUIT_ID = "circuit"
+CONF_CIRCUIT = vol.Schema(
+    {
+        vol.Required(CONF_NAME): cv.string,
+        vol.Required(CONF_CIRCUIT_ID): vol.All(vol.Coerce(int), vol.Range(min=0, max=63)),
+    }
+)
+
+
+PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
+    {
+        vol.Required(CONF_BASE_URL): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Required(CONF_CIRCUITS): vol.All(cv.ensure_list, [CONF_CIRCUIT]),
+    }
+)
+
+
+def setup_platform(hass, config, add_entities, discovery_info=None):
+    import pybmr
+
+    base_url = config.get(CONF_BASE_URL)
+    user = config.get(CONF_USERNAME)
+    password = config.get(CONF_PASSWORD)
+
+    bmr = pybmr.Bmr(base_url, user, password)
+    sensors = [
+        BmrControllerAwayMode(bmr),
+        BmrControllerPowerSwitch(bmr, config.get(CONF_CIRCUITS)),
+    ]
+
+    add_entities(sensors)
+
+
+class BmrControllerAwayMode(SwitchEntity):
+    """ Switch for the away mode (in HC64 called "low mode"). This is a global
+        state of the controller, not specific to a particular circuit. When the
+        controller is in "low mode" target temperature of all circuits is set to a
+        predefined temperature and no schedules are taken into account.
+    """
+
+    def __init__(self, bmr):
+        self._bmr = bmr
+        self._low_mode = {}
+
+    @property
+    def name(self):
+        """ Return the name of the entity.
+        """
+        return "BMR HC64 Away"
+
+    @property
+    def device_class(self):
+        return "switch"
+
+    @property
+    def is_on(self):
+        """ Return the state of the sensor.
+        """
+        return self._low_mode.get("start_date") is not None
+
+    @property
+    def device_state_attributes(self):
+        return {
+            "start_date": self._low_mode.get("user_offset"),
+            "end_date": self._low_mode.get("max_offset"),
+            "temperature": self._low_mode.get("temperature"),
+        }
+
+    def turn_on(self):
+        """ Turn on the Away mode.
+        """
+        self._bmr.setLowMode(True)
+
+    def turn_off(self):
+        """ Turn off the Away mode.
+        """
+        self._bmr.setLowMode(False)
+
+    @throttle(timedelta(seconds=30))
+    def update(self):
+        """ Fetch new state data for the sensor.
+            This is the only method that should fetch new data for Home Assistant.
+        """
+        try:
+            self._low_mode = self._bmr.getLowMode()
+        except socket.timeout:
+            _LOGGER.warn("Read from BMR HC64 controller timed out. Retrying later.")
+
+
+class BmrControllerPowerSwitch(SwitchEntity):
+    """ Turn heating on/off (in HC64 called "summer mode"). This is a global
+        state of the controller, not specific to a particular circuit.
+    """
+
+    def __init__(self, bmr, circuits):
+        self._bmr = bmr
+        self._circuits = circuits
+
+        self._summer_mode = None
+        self._summer_mode_assignments = {}
+
+    @property
+    def name(self):
+        """ Return the name of the entity.
+        """
+        return "BMR HC64 Power"
+
+    @property
+    def device_class(self):
+        return "switch"
+
+    @property
+    def is_on(self):
+        """ Return the state of the sensor.
+        """
+        return not (
+            self._summer_mode and all(self._summer_mode_assignments[x.get(CONF_CIRCUIT_ID)] for x in self._circuits)
+        )
+
+    def turn_on(self):
+        """ Turn the power on. Which means turn the summer mode off and remove
+            circuits from summer mode assignments.
+        """
+        self._bmr.setSummerMode(False)
+        self._bmr.setSummerModeAssignments([x.get(CONF_CIRCUIT_ID) for x in self._circuits], False)
+
+    def turn_off(self):
+        """ Turn the power off. Which means turn the summer mode on and add
+            circuits to the summer mode assignments.
+        """
+        self._bmr.setSummerMode(True)
+        self._bmr.setSummerModeAssignments([x.get(CONF_CIRCUIT_ID) for x in self._circuits], True)
+
+    @throttle(timedelta(seconds=30))
+    def update(self):
+        """ Fetch new state data for the sensor.
+            This is the only method that should fetch new data for Home Assistant.
+        """
+        self._summer_mode = self._bmr.getSummerMode()
+        self._summer_mode_assignments = self._bmr.getSummerModeAssignments()

--- a/custom_components/bmr/switch.py
+++ b/custom_components/bmr/switch.py
@@ -79,11 +79,19 @@ class BmrControllerAwayMode(SwitchEntity):
         self._bmr = bmr
         self._low_mode = {}
 
+        self._unique_id = f"{self._bmr.getUniqueId()}-switch-away"
+
     @property
     def name(self):
         """ Return the name of the entity.
         """
         return "BMR HC64 Away"
+
+    @property
+    def unique_id(self):
+        """ Return unique ID of the entity.
+        """
+        return self._unique_id
 
     @property
     def device_class(self):
@@ -133,6 +141,8 @@ class BmrControllerPowerSwitch(SwitchEntity):
         self._bmr = bmr
         self._circuits = circuits
 
+        self._unique_id = f"{self._bmr.getUniqueId()}-switch-power"
+
         self._summer_mode = None
         self._summer_mode_assignments = {}
 
@@ -141,6 +151,12 @@ class BmrControllerPowerSwitch(SwitchEntity):
         """ Return the name of the entity.
         """
         return "BMR HC64 Power"
+
+    @property
+    def unique_id(self):
+        """ Return unique ID of the entity.
+        """
+        return self._unique_id
 
     @property
     def device_class(self):

--- a/hacs.json
+++ b/hacs.json
@@ -4,7 +4,8 @@
     "domains": [
       "climate",
       "sensor",
-      "binary_sensor"
+      "binary_sensor",
+      "switch"
     ],
     "country": "CZ",
     "homeassistant": "0.110.0"


### PR DESCRIPTION
This is a follow-up to the https://github.com/slesinger/pybmr/pull/1.

I revamped the plugin a bit:

- Changed "sensor" entities to be "read-only" (i.e. the heating circuit target temperature can't be set using a sensor)
- Add "climate" entity - it can be used to set HVAC mode, target temperature, away mode, power on/off.
- Add the "switch" entity - support for the "away" mode and  "power on/off" (which are just a renames of "low mode" and "summer mode" into human language)
- Add the "binary_sensor" entity - it only contains the entity for reporting the state of HDO
- Update README.md

Check out the readme and comments in code for details. I tried to document the what and why in there.

Note that these changes require the revamped pybmr library linked above.

Let me know what you think, as always comments/suggestions are welcome.