### PR TITLE
Remove getNumCircuits() call in sensor.setup_platform() to speed-up startup

### DIFF
--- a/custom_components/bmr/sensor.py
+++ b/custom_components/bmr/sensor.py
@@ -62,14 +62,10 @@ def setup_platform(hass, config, add_entities, discovery_info=None):
     password = config.get(CONF_PASSWORD)
 
     bmr = pybmr.Bmr(base_url, user, password)
-    num_circuits = bmr.getNumCircuits()
     sensors = []
     for circuit_config in config.get(CONF_CIRCUITS):
-        if circuit_config.get(CONF_CIRCUIT_ID) < num_circuits:
-            sensors.append(BmrCircuitTemperature(bmr, circuit_config))
-            sensors.append(BmrCircuitTargetTemperature(bmr, circuit_config))
-        else:
-            _LOGGER.warn(f"Circuit ID {circuit_config.get(CONF_CIRCUIT_ID)} is out of range")
+        sensors.append(BmrCircuitTemperature(bmr, circuit_config))
+        sensors.append(BmrCircuitTargetTemperature(bmr, circuit_config))
 
     add_entities(sensors)
 


### PR DESCRIPTION
It was causing issues in case the BMR controller wasn't accessible during HA startup.